### PR TITLE
Introduce `floor_thickness` variable

### DIFF
--- a/src/skirmishbunker/bunkerBody.py
+++ b/src/skirmishbunker/bunkerBody.py
@@ -7,6 +7,7 @@ def init_body_params(self):
     self.int_length = None
     self.int_width = None
     self.base_height = 3
+    self.floor_thickness = 3
 
     self.angle = 0
     self.inset = 10
@@ -35,8 +36,8 @@ def make_interior_rectangle(self):
 
     self.interior_rectangle = (
         cq.Workplane("XY")
-        .box(self.int_length, self.int_width, self.height-self.wall_width)
-        .translate((0,0,self.wall_width/2))
+        .box(self.int_length, self.int_width, self.height)
+        .translate((0, 0, self.floor_thickness))
     )
 
 def make_base(self):

--- a/src/skirmishbunker/bunkerBody.py
+++ b/src/skirmishbunker/bunkerBody.py
@@ -7,7 +7,7 @@ def init_body_params(self):
     self.int_length = None
     self.int_width = None
     self.base_height = 3
-    self.floor_thickness = 3
+    self.floor_thickness = None
 
     self.angle = 0
     self.inset = 10
@@ -29,6 +29,11 @@ def make_wedge(self):
 def make_interior_rectangle(self):
     self.int_length = self.length - (2*(self.inset+self.wall_width))
     self.int_width = self.width - (2*(self.inset+self.wall_width))
+   
+    if self.floor_thickness:
+        floor_thickness = self.floor_thickness
+    else:
+        floor_thickness = self.wall_width
 
     if self.inset < 0:
         self.int_length = self.length - (2*(self.wall_width))
@@ -36,8 +41,8 @@ def make_interior_rectangle(self):
 
     self.interior_rectangle = (
         cq.Workplane("XY")
-        .box(self.int_length, self.int_width, self.height)
-        .translate((0, 0, self.floor_thickness))
+        .box(self.int_length, self.int_width, self.height - floor_thickness)
+        .translate((0, 0, floor_thickness / 2))
     )
 
 def make_base(self):

--- a/src/skirmishbunker/bunkerFloor.py
+++ b/src/skirmishbunker/bunkerFloor.py
@@ -21,6 +21,11 @@ def make_interior_floor(self):
     int_length = self.int_length-self.floor_padding
     int_width = self.int_width-self.floor_padding
 
+    if self.floor_thickness:
+        floor_thickness = self.floor_thickness
+    else:
+        floor_thickness = self.wall_width
+
     if self.custom_floor_tile:
         floor_tile = self.custom_floor_tile(self)
     else:
@@ -29,7 +34,7 @@ def make_interior_floor(self):
     columns = math_floor(int_width/(tile_size + tile_padding))
     rows = math_floor(int_length/(tile_size + tile_padding))
     tile_grid = grid.make_grid(part=floor_tile, dim = [tile_size + tile_padding, tile_size + tile_padding], columns = columns, rows = rows)
-    z_tile_translate = -1 * (self.height/2-self.floor_tile_height / 2 - self.floor_thickness)
+    z_tile_translate = -1 * (self.height / 2 - self.floor_tile_height / 2 - floor_thickness)
 
     #print('z_tile_translate',z_tile_translate)
     self.interior_tiles = tile_grid.translate((0,0,z_tile_translate))

--- a/src/skirmishbunker/bunkerFloor.py
+++ b/src/skirmishbunker/bunkerFloor.py
@@ -29,7 +29,7 @@ def make_interior_floor(self):
     columns = math_floor(int_width/(tile_size + tile_padding))
     rows = math_floor(int_length/(tile_size + tile_padding))
     tile_grid = grid.make_grid(part=floor_tile, dim = [tile_size + tile_padding, tile_size + tile_padding], columns = columns, rows = rows)
-    z_tile_translate = -1*(self.height/2-self.floor_tile_height/2-self.wall_width)
+    z_tile_translate = -1 * (self.height/2-self.floor_tile_height / 2 - self.floor_thickness)
 
     #print('z_tile_translate',z_tile_translate)
     self.interior_tiles = tile_grid.translate((0,0,z_tile_translate))

--- a/src/skirmishbunker/bunkerFloorCuts.py
+++ b/src/skirmishbunker/bunkerFloorCuts.py
@@ -11,7 +11,7 @@ def init_floor_cut(self):
     self.floor_cuts = None
 
 def make_floor_cuts(self):
-    height = self.wall_width + self.base_height + self.floor_tile_height
+    height = self.floor_thickness + self.base_height + self.floor_tile_height
     z_translate = (-1*(self.height/2)) - self.base_height + (height/2) #+ (self.floor_tile_height/2)
 
     floor_cut = (

--- a/src/skirmishbunker/bunkerFloorCuts.py
+++ b/src/skirmishbunker/bunkerFloorCuts.py
@@ -11,7 +11,13 @@ def init_floor_cut(self):
     self.floor_cuts = None
 
 def make_floor_cuts(self):
-    height = self.floor_thickness + self.base_height + self.floor_tile_height
+
+    if self.floor_thickness:
+        floor_thickness = self.floor_thickness
+    else:
+        floor_thickness = self.wall_width
+
+    height = floor_thickness + self.base_height + self.floor_tile_height
     z_translate = (-1*(self.height/2)) - self.base_height + (height/2) #+ (self.floor_tile_height/2)
 
     floor_cut = (


### PR DESCRIPTION
I noticed that the floors were actually very thick (they were base thickness + a factor of wall thickness). I would prefer slightly thinner floors, so I have added a `floor_thickness` variable that is used instead of a factor of `wall_width`.

I have also updated `make_floor_cuts`, but I could not work out what this method is for, so haven't tested it...